### PR TITLE
_decoder.get_next() may return None

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -233,5 +233,4 @@ class TestFileWebp:
             im.save(out_webp, save_all=True)
 
         with Image.open(out_webp) as reloaded:
-            reloaded.load()
             assert reloaded.info["duration"] == 1000

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -93,7 +93,7 @@ class WebPImageFile(ImageFile.ImageFile):
             self.info["xmp"] = xmp
 
         # Initialize seek state
-        self._reset(reset=True)
+        self._reset()
 
     def _getexif(self):
         if "exif" not in self.info:
@@ -116,9 +116,8 @@ class WebPImageFile(ImageFile.ImageFile):
         # Set logical frame to requested position
         self.__logical_frame = frame
 
-    def _reset(self, reset=True):
-        if reset:
-            self._decoder.reset()
+    def _reset(self):
+        self._decoder.reset()
         self.__physical_frame = 0
         self.__loaded = -1
         self.__timestamp = 0

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -74,9 +74,9 @@ class WebPImageFile(ImageFile.ImageFile):
         self.info["background"] = (bg_r, bg_g, bg_b, bg_a)
         self.n_frames = frame_count
         self.is_animated = self.n_frames > 1
-        _, ts = self._decoder.get_next()
-        if ts:
-            self.info["duration"] = ts
+        ret = self._decoder.get_next()
+        if ret is not None:
+            self.info["duration"] = ret[1]
         self._mode = "RGB" if mode == "RGBX" else mode
         self.rawmode = mode
         self.tile = []


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7311

Three changes
- you've removed the only instance of `self._reset(reset=False)`. If "reset" is always true, then `def _reset(self, reset=True)`  can just become `def _reset(self)`
- `self._decoder.get_next()` may return `None`. See https://github.com/python-pillow/Pillow/blob/15e52290303008c0888dc17aab069edb5cff3a25/src/PIL/WebPImagePlugin.py#L128-L132. So I've added a change to handle that
- I've made a change to the tests so that they fail without your change and pass with them. This will help prevent your change from being undone in the future.